### PR TITLE
Remove target encrypted file if decryption fails

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,11 +2,15 @@
 class gpgfile::params {
   case $::osfamily {
     'RedHat': {
-      $gpg_command = '/usr/bin/gpg'
+      $exec_path = [ '/bin', '/usr/bin' ]
+      $gpg_command = 'gpg'
+      $rm_command = 'rm'
     }
     default: {
       warning("Warning - unsupported OS family ${::osfamily} - correct operation not guaranteed")
-      $gpg_command = '/usr/bin/gpg'
+      $exec_path = [ '/bin', '/usr/bin' ]
+      $gpg_command = 'gpg'
+      $rm_command = 'rm'
     }
   }
 }


### PR DESCRIPTION
This fixes issue #8 - a failed decryption leaves an empty decrypted
file, which prevents another attempt to decrypt.  By removing the
encrypted file, the encrypted file will be re-created on the next
puppet run, which will trigger another decryption attempt.