### PR TITLE
Move release gems into new `release` group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - bundle -v
 script:
   - 'bundle exec rake $CHECK'
-bundler_args: --without system_tests --without development
+bundler_args: --without "system_tests release"
 rvm:
   - 2.3.1
   - 2.1.7

--- a/Gemfile
+++ b/Gemfile
@@ -28,20 +28,16 @@ group :development do
   gem "fast_gettext",                                  require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
   gem "json_pure", '<= 2.0.1',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
-  gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby] if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
-  gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby] if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
-  gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw] if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
-  gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw] if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
+  gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+end
+
+group :release do
   gem "puppet-blacksmith"
   gem "activesupport", "< 5.0.0"
   gem "github_changelog_generator"
-end
-group :travisci do
-  gem "rake", '< 12.1.0',       require: false if ENV['TRAVIS'] and Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "puppetlabs_spec_helper", require: false if ENV['TRAVIS']
-  gem "rubocop",                require: false if ENV['TRAVIS'] and Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
-  gem "rubocop-rspec",          require: false if ENV['TRAVIS'] and Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
-  gem "metadata-json-lint",     require: false if ENV['TRAVIS'] and Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
In order to use a more PDK-compatible `.travis.yml` file, the
`development` gem group needs to be installed during Travis runs.
Therefore, I'm moving the gems used for release into a new
`release` group which will be excluded from Travis runs.

This also removes the now-unnecessary `travisci` group, since
the `development` group will pull in the required gems.