### PR TITLE
More release improvements

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,2 @@
+project=puppet-gpgfile
+include-labels=bug,enhancement

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 * `bundle install --without development`
 * `bundle exec rake module:bump:minor` (or ...`:patch` or ...`:major`)
-* `github_changelog_generator --future-release $(bundle exec rake module:version) --user` _<GitHub-username>_ `--project puppet-gpgfile`
+* `github_changelog_generator --future-release $(bundle exec rake module:version) --user` _<GitHub-username>_
 * `git add CHANGELOG.md metadata.json`
 * `git commit -m "Bump commit to $(bundle exec rake module:version)"`
 * `bundle exec rake module:tag`


### PR DESCRIPTION
Add `.github_changelog_generator` with default options
Remove `--project` option from `RELEASING.md`